### PR TITLE
編集画面の遷移と更新時、編集画面に書いてあった文書が表示できた。

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -47,7 +47,7 @@ class TasksController < ApplicationController
   end
 
   def destroy
-    task = current_user.tasks.find(params[:id])
+    task = current_user.tasks.find(params[:board_id])
     task.destroy!
     redirect_to root_path, notice: '削除に成功しました'
   end

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -1,0 +1,19 @@
+.container
+  %ul
+    - @task.errors.full_messages.each do |message|
+      %li= message
+  = form_with(model:@task, url: board_task_path(@task), local: true) do |f|
+    %div 
+      = f.label :eyecatch, 'アイキャッチ'
+    %div 
+      = f.file_field :eyecatch 
+    %div
+      = f.label :title, 'Name'
+    %div
+      = f.text_field :title, class: 'text'
+    %div
+      = f.label :content, 'Description'
+    %div
+      = f.text_area :content
+    
+    = f.submit 'submit', class: 'btn-primary'

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,19 +1,21 @@
-.container
-  %ul
-    - @task.errors.full_messages.each do |message|
-      %li= message
-  = form_with(model: @task, url: board_task_path(@task), local: true) do |f|
-    %div 
-      = f.label :eyecatch, 'アイキャッチ'
-    %div 
-      = f.file_field :eyecatch 
-    %div
-      = f.label :title, 'Name'
-    %div
-      = f.text_field :title, class: 'text'
-    %div
-      = f.label :description, 'Description'
-    %div
-      = f.text_area :description
+= render 'form', task: @board
+
+-# .container
+-#   %ul
+-#     - @task.errors.full_messages.each do |message|
+-#       %li= message
+-#   = form_with(model:@task, url: board_task_path(@task), local: true) do |f|
+-#     %div 
+-#       = f.label :eyecatch, 'アイキャッチ'
+-#     %div 
+-#       = f.file_field :eyecatch 
+-#     %div
+-#       = f.label :title, 'Name'
+-#     %div
+-#       = f.text_field :title, class: 'text'
+-#     %div
+-#       = f.label :description, 'Description'
+-#     %div
+-#       = f.text_area :description
     
-    = f.submit 'submit', class: 'btn-primary'
+-#     = f.submit 'submit', class: 'btn-primary'


### PR DESCRIPTION
原因はhtmlの中のクラスがコンテントとディスクリプションで異なっていたため。